### PR TITLE
README: fix repo name in example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ jobs:
     name: Formalities
     steps:
       - name: Check formalities
-        uses: georgesapkin/stickler@main
+        uses: georgesapkin/hyperstickler@main
         with:
           check_signoff: true
           exclude_weblate: true


### PR DESCRIPTION
It was referencing the old repository name (stickler) instead of hyperstickler.