### PR TITLE
tests: use numeric comparison for cross-platform compatibility

### DIFF
--- a/src/test.sh
+++ b/src/test.sh
@@ -737,7 +737,7 @@ main() {
 	echo $'\nTest suite finished'
 	echo "Summary: $pass_count/$test_count tests passed"
 
-	[ "$pass_count" != "$test_count" ] \
+	[ "$pass_count" -ne "$test_count" ] \
 		&& exit 1 \
 		|| exit 0
 }


### PR DESCRIPTION
Another macOS issue. 😭  Easily reproduced by this one:
```bash
wc -l  action.yml
     118 action.yml
```

The 'wc -l' command produces output with leading whitespace on BSD/macOS
systems (e.g., '      34'), while Linux outputs without padding (e.g., '34').
This caused string comparison (!=) to incorrectly fail on macOS even when
test counts matched numerically.

Switch to numeric comparison (-ne) which automatically strips whitespace and correctly compares integer values across all platforms.

